### PR TITLE
preventdefault actions for backspace and tab 

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -408,8 +408,11 @@ Emscripten_HandleKey(int eventType, const EmscriptenKeyboardEvent *keyEvent, voi
         }
     }
 
-    /* if we prevent keydown, we won't get keypress*/
-    return SDL_GetEventState(SDL_TEXTINPUT) != SDL_ENABLE || eventType != EMSCRIPTEN_EVENT_KEYDOWN;
+    /* if we prevent keydown, we won't get keypress
+     * also we need to ALWAYS prevent backspace and tab otherwise chrome takes action and does bad navigation UX
+     */
+    return SDL_GetEventState(SDL_TEXTINPUT) != SDL_ENABLE || eventType != EMSCRIPTEN_EVENT_KEYDOWN
+            || keyEvent->keyCode == 8 /* backspace */ || keyEvent->keyCode == 9 /* tab */;
 }
 
 int


### PR DESCRIPTION
so chrome doesn't initiate navigation actions..  

implements fix for #23 
