### PR TITLE
allow overriding the keyboard bind element via the SDL hint system

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -457,7 +457,19 @@ extern "C" {
  */
 #define SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES    "SDL_VIDEO_MAC_FULLSCREEN_SPACES"
 
-
+/**
+ *  \brief override the binding element for keyboard inputs for Emscripten builds
+ *
+ * This hint only applies to the emscripten platform
+ *
+ * The variable can be one of
+ *    "#window"      - The javascript window object (this is the default)
+ *    "#document"    - The javascript document object
+ *    "#screen"      - the javascript window.screen object
+ *    "#canvas"      - the WebGL canvas element
+ *    any other string without a leading # sign apples to the element on the page with that ID.
+ */
+#define SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT   "SDL_EMSCRIPTEN_KEYBOARD_ELEMENT"
 /**
  *  \brief  An enumeration of hint priorities
  */

--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -33,6 +33,8 @@
 #include "SDL_emscriptenevents.h"
 #include "SDL_emscriptenvideo.h"
 
+#include "SDL_hints.h"
+
 #define FULLSCREEN_MASK ( SDL_WINDOW_FULLSCREEN_DESKTOP | SDL_WINDOW_FULLSCREEN )
 
 /*
@@ -574,10 +576,12 @@ Emscripten_RegisterEventHandlers(SDL_WindowData *data)
     emscripten_set_touchcancel_callback("#canvas", data, 0, Emscripten_HandleTouch);
 
     /* Keyboard events are awkward */
-    emscripten_set_keydown_callback("#window", data, 0, Emscripten_HandleKey);
-    emscripten_set_keyup_callback("#window", data, 0, Emscripten_HandleKey);
+    const char *keyElement = SDL_GetHint(SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT);
+    if (!keyElement) keyElement = "#window";
 
-    emscripten_set_keypress_callback("#window", data, 0, Emscripten_HandleKeyPress);
+    emscripten_set_keydown_callback(keyElement, data, 0, Emscripten_HandleKey);
+    emscripten_set_keyup_callback(keyElement, data, 0, Emscripten_HandleKey);
+    emscripten_set_keypress_callback(keyElement, data, 0, Emscripten_HandleKeyPress);
 
     emscripten_set_fullscreenchange_callback("#document", data, 0, Emscripten_HandleFullscreenChange);
 


### PR DESCRIPTION
This allows overriding the keyboard bind element via the SDL Hint system..    e.g. in a pre-run you simply do

``` javascript
Module['preRun'].push(function() {
     ENV.SDL_EMSCRIPTEN_KEYBOARD_ELEMENT = "#document";
});
```
